### PR TITLE
added header files to make dist

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,8 @@ bin_PROGRAMS = unixcat
 unixcat_SOURCES = unixcat.c
 unixcat_LDADD = -lpthread
 
+EXTRA_DIST = *.h
+
 pkglib_LIBRARIES = livestatus.so
 
 livestatus_so_SOURCES = \


### PR DESCRIPTION
The header files on a make dist were missing. This should fix it.
